### PR TITLE
Use source.js.regexp provided by the Javascript grammar

### DIFF
--- a/JavaScript (Babel).YAML-tmLanguage
+++ b/JavaScript (Babel).YAML-tmLanguage
@@ -1049,7 +1049,7 @@ repository:
         '1': {name: punctuation.definition.string.end.js}
         '2': {name: keyword.other.js}
       patterns:
-      - include: source.regexp.js
+      - include: source.js.regexp
 
   literal-string:
     patterns:

--- a/JavaScript (Babel).tmLanguage
+++ b/JavaScript (Babel).tmLanguage
@@ -3274,7 +3274,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>source.regexp.js</string>
+							<string>source.js.regexp</string>
 						</dict>
 					</array>
 				</dict>


### PR DESCRIPTION
I've been working on improving the grammar compiler for Linguist and I noticed it reporting this problem:

```
- [ ] repository `vendor/grammars/babel-sublime` (from https://github.com/github-linguist/babel-sublime) (1 errors)
    - [ ] Missing include in grammar: `source.js.jsx` (in `JavaScript (Babel).tmLanguage`) attempts to include `source.regexp.js` but the scope cannot be found
```

This is caused by the babel grammar never including the `Regular Expressions (JavaScriptNext).YAML-tmLanguage` and `Regular Expressions (JavaScriptNext).tmLanguage` files in https://github.com/babel/babel-sublime/commit/cc420f2cab2a3c62e1216532f41d40fafa41e03d when it started out.

Rather than including them and taking our fork too much further away from upstream, I'm switching this to use `source.js.regexp` as provided by the Javascript grammar we use on Linguist. Quite a few other grammars in Linguist use this, so adding another shouldn't be the end of the world. It does however mean that this becomes another grammar that'll start reporting problems if/when we replace the Javascript grammar as I attempted in https://github.com/github/linguist/issues/3044#issuecomment-459420383